### PR TITLE
feat(dap): check the `mason-registry` to validate if `debug_adapter` is installed and get the path.

### DIFF
--- a/nvim/.config/nvim/lua/alpha/dap.lua
+++ b/nvim/.config/nvim/lua/alpha/dap.lua
@@ -38,14 +38,21 @@ vim.fn.sign_define("DapLogPoint", { text = "💬", texthl = "", linehl = "", num
 
 -- vim.cmd("au FileType dap-repl lua require('dap.ext.autocompl').attach()")
 
--- TODO replace with mason for check if installed and get the path
 -- the binary does not work
-local php_debug_adapter = vim.fn.stdpath("data") .. "/mason/packages/php-debug-adapter/extension/out/phpDebug.js"
+local ok, php_debug_adapter = pcall(require("mason-registry").get_package, "php_debug_adapter")
+
+-- TODO: choose action in case adapter is not installed with `mason.nvim`.
+-- For example:
+-- if not ok then
+	-- the binary is not installed.
+	-- vim.notify("the php_debug_adapter is not installed with mason.nvim")
+    	-- return
+-- end
 
 dap.adapters.php = {
 	type = "executable",
 	command = "node",
-	args = { php_debug_adapter },
+	args = { php_debug_adapter:get_install_path() .. "/extension/out/phpDebug.js" },
 }
 dap.configurations.php = {
 	{


### PR DESCRIPTION
Hi! @adalessa - this little contribution is to check if `php_debug_adapter` is installed and then get its installation path, via the `get_package` method of `mason-registry`.

Closes TODO: https://github.com/adalessa/dotfiles/blob/8ba09d9618abafbc3b40b7bd1a52b47b7d63c96e/nvim/.config/nvim/lua/alpha/dap.lua#L41