### PR TITLE
Fix Packer being stuck at MacOS

### DIFF
--- a/nvim/.config/nvim/lua/alpha/plugins.lua
+++ b/nvim/.config/nvim/lua/alpha/plugins.lua
@@ -5,6 +5,13 @@ end
 vim.cmd.packadd("packer.nvim")
 vim.cmd([[autocmd BufWritePost plugins.lua source <afile> | PackerCompile]])
 
+-- packer in MacOS  keeps being stuck at :PackerSync if jobs are not limited.
+-- uncomment for OSX
+--local packer = require('packer')
+--packer.init {
+--    max_jobs = 5,
+--}
+
 return require("packer").startup(function(use)
 	local local_use = function(first, second, opts)
 		opts = opts or {}


### PR DESCRIPTION
Packer in MacOS  keeps being stuck at :PackerSync if jobs are not limited.

Uncomment to Fix at dotfiles/nvim/.config/nvim/lua/alpha/plugins.lua to solve it

--
Packer en MacOS se queda parado al ejecutar :PackerSync si no se limita el número de trabajos simultáneos.

Descomentar el arhivo dotfiles/nvim/.config/nvim/lua/alpha/plugins.lua para solucionarlo.
